### PR TITLE
Add manual start of collecting statistics function and add regress test 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ make && make install
 gp_relsizes_stats configuration parameters:
 | **Parameter** | **Type**     | **Default**  | **Default**  |
 | ---------------- | --------------- | ------------ | ------------ |
-| `gp_relsizes_stats.enabled`          | bool    | true     | Using `gp_relsizes_stats.enabled` you can enable/disable stats collection functions for database where extension installed.|
 | `gp_relsizes_stats.bgw_enabled`      | bool    | false    | Using `gp_relsizes_stats.bgw_enabled` you can enable/disable background stats collection for database where extension installed (actually enable/disable background worker which collecting stats).|
 | `gp_relsizes_stats.restart_naptime`  | int     | 21600000 | Using `gp_relsizes_stats.restart_naptime` you can set naptime between each startup of collecting process. Value set time in milliseconds. Default is equal to 6 hours.|
 | `gp_relsizes_stats.database_naptime` | int     | 0        | Using `gp_relsizes_stats.database_naptime` you can set naptime between collecting stats for each databases. Value set time in milliseconds. Default is equal to 0 milliseconds.|

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make && make install
 gp_relsizes_stats configuration parameters:
 | **Parameter** | **Type**     | **Default**  | **Default**  |
 | ---------------- | --------------- | ------------ | ------------ |
-| `gp_relsizes_stats.bgw_enabled`      | bool    | false    | Using `gp_relsizes_stats.bgw_enabled` you can enable/disable background stats collection for database where extension installed (actually enable/disable background worker which collecting stats).|
+| `gp_relsizes_stats.enabled`          | bool    | false    | Using `gp_relsizes_stats.enabled` you can enable/disable background stats collection for database where extension installed (actually enable/disable background worker which collecting stats).|
 | `gp_relsizes_stats.restart_naptime`  | int     | 21600000 | Using `gp_relsizes_stats.restart_naptime` you can set naptime between each startup of collecting process. Value set time in milliseconds. Default is equal to 6 hours.|
 | `gp_relsizes_stats.database_naptime` | int     | 0        | Using `gp_relsizes_stats.database_naptime` you can set naptime between collecting stats for each databases. Value set time in milliseconds. Default is equal to 0 milliseconds.|
 | `gp_relsizes_stats.file_naptime`     | int     | 1        | Using `gp_relsizes_stats.file_naptime` you can set naptime between each file stats calculating. Value set time in milliseconds. Default is equal to 1 millisecond.|

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ make && make install
 gp_relsizes_stats configuration parameters:
 | **Parameter** | **Type**     | **Default**  | **Default**  |
 | ---------------- | --------------- | ------------ | ------------ |
-| `gp_relsizes_stats.enabled`          | bool    | false    | Using `gp_relsizes_stats.enabled` you can enable/disable stats collection for database where extension installed.|
+| `gp_relsizes_stats.enabled`          | bool    | true     | Using `gp_relsizes_stats.enabled` you can enable/disable stats collection functions for database where extension installed.|
+| `gp_relsizes_stats.bgw_enabled`      | bool    | false    | Using `gp_relsizes_stats.bgw_enabled` you can enable/disable background stats collection for database where extension installed (actually enable/disable background worker which collecting stats).|
 | `gp_relsizes_stats.restart_naptime`  | int     | 21600000 | Using `gp_relsizes_stats.restart_naptime` you can set naptime between each startup of collecting process. Value set time in milliseconds. Default is equal to 6 hours.|
 | `gp_relsizes_stats.database_naptime` | int     | 0        | Using `gp_relsizes_stats.database_naptime` you can set naptime between collecting stats for each databases. Value set time in milliseconds. Default is equal to 0 milliseconds.|
 | `gp_relsizes_stats.file_naptime`     | int     | 1        | Using `gp_relsizes_stats.file_naptime` you can set naptime between each file stats calculating. Value set time in milliseconds. Default is equal to 1 millisecond.|

--- a/sql/gp_relsizes_stats--1.0.sql
+++ b/sql/gp_relsizes_stats--1.0.sql
@@ -83,7 +83,7 @@ RETURNS TABLE (segment INTEGER, relfilenode OID, filepath TEXT, size BIGINT, mti
 AS 'MODULE_PATHNAME', 'get_stats_for_database'
 LANGUAGE C STRICT EXECUTE ON ALL SEGMENTS;
 
-CREATE FUNCTION relsizes_stats_schema.relsizes_collect_stats()
+CREATE FUNCTION relsizes_stats_schema.relsizes_collect_stats_once()
 RETURNS void
 AS 'MODULE_PATHNAME', 'relsizes_collect_stats_once'
-LANGUAGE C VOLATILE EXECUTE ON MASTER;
+LANGUAGE C STRICT EXECUTE ON MASTER;

--- a/sql/gp_relsizes_stats--1.0.sql
+++ b/sql/gp_relsizes_stats--1.0.sql
@@ -83,3 +83,7 @@ RETURNS TABLE (segment INTEGER, relfilenode OID, filepath TEXT, size BIGINT, mti
 AS 'MODULE_PATHNAME', 'get_stats_for_database'
 LANGUAGE C STRICT EXECUTE ON ALL SEGMENTS;
 
+CREATE FUNCTION relsizes_stats_schema.relsizes_collect_stats()
+RETURNS void
+AS 'MODULE_PATHNAME', 'relsizes_collect_stats_once'
+LANGUAGE C VOLATILE EXECUTE ON MASTER;

--- a/src/gp_relsizes_stats.c
+++ b/src/gp_relsizes_stats.c
@@ -576,7 +576,6 @@ cleanup:
 void relsizes_collect_stats(Datum main_arg) {
     int retcode = 0;
     int databases_cnt;
-    int create_transaction = 1;
     Datum *databases_oids;
 
     pqsignal(SIGTERM, worker_sigterm);
@@ -592,7 +591,7 @@ void relsizes_collect_stats(Datum main_arg) {
         }
 
         /* get databases oids with database's names */
-        databases_oids = get_databases_oids(&databases_cnt, CurrentMemoryContext, create_transaction);
+        databases_oids = get_databases_oids(&databases_cnt, CurrentMemoryContext, 1);
         /* start collecting stats for databases */
         get_stats_for_databases(databases_oids, databases_cnt);
         /* free allocated memory for data about databases */
@@ -613,10 +612,9 @@ bgw_sleep:
 Datum relsizes_collect_stats_once(PG_FUNCTION_ARGS) {
     int databases_cnt;
     Datum *databases_oids;
-    int create_transaction = 0;
 
     /* get databases oids with database's names */
-    databases_oids = get_databases_oids(&databases_cnt, CurrentMemoryContext, create_transaction);
+    databases_oids = get_databases_oids(&databases_cnt, CurrentMemoryContext, 0);
     /* start collecting stats for databases */
     get_stats_for_databases(databases_oids, databases_cnt);
     /* free allocated memory for data about databases */

--- a/src/gp_relsizes_stats.c
+++ b/src/gp_relsizes_stats.c
@@ -42,7 +42,9 @@
 PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(get_stats_for_database);
+PG_FUNCTION_INFO_V1(relsizes_collect_stats_once);
 Datum get_stats_for_database(PG_FUNCTION_ARGS);
+Datum relsizes_collect_stats_once(PG_FUNCTION_ARGS);
 
 static void worker_sigterm(SIGNAL_ARGS);
 static Datum *get_databases_oids(int *databases_cnt, MemoryContext ctx);
@@ -597,6 +599,20 @@ void relsizes_collect_stats(Datum main_arg) {
             proc_exit(1);
         }
     }
+}
+
+Datum relsizes_collect_stats_once(PG_FUNCTION_ARGS) {
+    int databases_cnt;
+    Datum *databases_oids;
+
+    /* get databases oids with database's names */
+    databases_oids = get_databases_oids(&databases_cnt, CurrentMemoryContext);
+    /* start collecting stats for databases */
+    get_stats_for_databases(databases_oids, databases_cnt);
+    /* free allocated memory for data about databases */
+    pfree(databases_oids);
+
+    PG_RETURN_VOID();
 }
 
 static void relsizes_shmem_startup() {

--- a/src/gp_relsizes_stats.c
+++ b/src/gp_relsizes_stats.c
@@ -596,7 +596,7 @@ void relsizes_collect_stats(Datum main_arg) {
         get_stats_for_databases(databases_oids, databases_cnt);
         /* free allocated memory for data about databases */
         pfree(databases_oids);
-bgw_sleep:
+    bgw_sleep:
         /* sleep for restart_naptime time */
         retcode =
             WaitLatch(&MyProc->procLatch, WL_LATCH_SET | WL_TIMEOUT | WL_POSTMASTER_DEATH, worker_restart_naptime);
@@ -640,8 +640,8 @@ static void relsizes_shmem_startup() {
 
 void _PG_init(void) {
     /* define GUC bgw enable flag */
-    DefineCustomBoolVariable("gp_relsizes_stats.enabled", "Enable main background worker flag", NULL, &enabled,
-                             false, PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
+    DefineCustomBoolVariable("gp_relsizes_stats.enabled", "Enable main background worker flag", NULL, &enabled, false,
+                             PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
     /* define GUC naptime variables */
     DefineCustomIntVariable("gp_relsizes_stats.restart_naptime", "Duration between every collect-phases (in ms).", NULL,
                             &worker_restart_naptime,

--- a/src/gp_relsizes_stats.c
+++ b/src/gp_relsizes_stats.c
@@ -69,7 +69,7 @@ void relsizes_database_stats_job(Datum args);
 static int worker_restart_naptime = 0;  /* set up in _PG_init() function */
 static int worker_database_naptime = 0; /* set up in _PG_init() function */
 static int worker_file_naptime = 0;     /* set up in _PG_init() function */
-static bool bgw_enabled = false;        /* set up in _PG_init() function */
+static bool enabled = false;            /* set up in _PG_init() function */
 
 static volatile sig_atomic_t got_sigterm = false;
 
@@ -585,8 +585,8 @@ void relsizes_collect_stats(Datum main_arg) {
     while (!got_sigterm) {
 
         /* check if background worker enabled */
-        char *bgw_enabled_option = GetConfigOptionByName("gp_relsizes_stats.bgw_enabled", NULL);
-        if (strcmp(bgw_enabled_option, "on") != 0) {
+        char *enabled_option = GetConfigOptionByName("gp_relsizes_stats.enabled", NULL);
+        if (strcmp(enabled_option, "on") != 0) {
             goto bgw_sleep;
         }
 
@@ -640,7 +640,7 @@ static void relsizes_shmem_startup() {
 
 void _PG_init(void) {
     /* define GUC bgw enable flag */
-    DefineCustomBoolVariable("gp_relsizes_stats.bgw_enabled", "Enable main background worker flag", NULL, &bgw_enabled,
+    DefineCustomBoolVariable("gp_relsizes_stats.enabled", "Enable main background worker flag", NULL, &enabled,
                              false, PGC_SIGHUP, GUC_NOT_IN_SAMPLE, NULL, NULL, NULL);
     /* define GUC naptime variables */
     DefineCustomIntVariable("gp_relsizes_stats.restart_naptime", "Duration between every collect-phases (in ms).", NULL,

--- a/test/expected/gp_relsizes_stats.out
+++ b/test/expected/gp_relsizes_stats.out
@@ -24,25 +24,9 @@ SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'empl
 (1 row)
 
 -- Fill table with a lot of different rows
-DO $$
-DECLARE
-    i INT;
-BEGIN
-    FOR i IN 1..10000 LOOP
-        INSERT INTO employees (
-            first_name, 
-            last_name, 
-            department_id, 
-            date_of_birth
-        )
-        VALUES (
-            'First' || i,                        -- Generate a first name
-            'Last' || i,                         -- Generate a last name
-            (i % 10) + 1,                        -- Cycle through 10 department IDs
-            DATE '1980-01-01' + (i % 365 * 365 / 30) -- Simulated birth dates
-        );
-    END LOOP;
-END $$;
+insert into employees (first_name, last_name, department_id, date_of_birth) 
+select 'First' || i, 'Last' || i, (i % 10) + 1, DATE '1980-01-01' + (i % 365 * 365 / 30) 
+from generate_series(1, 10001)i;
 SELECT relsizes_stats_schema.relsizes_collect_stats_once();
  relsizes_collect_stats_once 
 -----------------------------

--- a/test/expected/gp_relsizes_stats.out
+++ b/test/expected/gp_relsizes_stats.out
@@ -1,1 +1,71 @@
 CREATE EXTENSION gp_relsizes_stats;
+DROP TABLE IF EXISTS employees;
+CREATE TABLE employees (
+    employee_id SERIAL PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    department_id INT,
+    date_of_birth DATE
+);
+INSERT INTO employees (first_name, last_name, department_id, date_of_birth) VALUES
+('John', 'Doe', 1, '1988-06-15'),
+('Jane', 'Smith', 2, '1990-07-20'),
+('Emily', 'Jones', 1, '1985-08-30');
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
+ size  
+-------
+ 65536
+(1 row)
+
+-- Fill table with a lot of different rows
+DO $$
+DECLARE
+    i INT;
+BEGIN
+    FOR i IN 1..10000 LOOP
+        INSERT INTO employees (
+            first_name, 
+            last_name, 
+            department_id, 
+            date_of_birth
+        )
+        VALUES (
+            'First' || i,                        -- Generate a first name
+            'Last' || i,                         -- Generate a last name
+            (i % 10) + 1,                        -- Cycle through 10 department IDs
+            DATE '1980-01-01' + (i % 365 * 365 / 30) -- Simulated birth dates
+        );
+    END LOOP;
+END $$;
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+-- Check that collected stats are correct
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
+  size  
+--------
+ 950272
+(1 row)
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+-- Validate that after rerun stats collection size of table has not change
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
+  size  
+--------
+ 950272
+(1 row)
+

--- a/test/sql/gp_relsizes_stats.sql
+++ b/test/sql/gp_relsizes_stats.sql
@@ -19,25 +19,9 @@ SELECT relsizes_stats_schema.relsizes_collect_stats_once();
 SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
 
 -- Fill table with a lot of different rows
-DO $$
-DECLARE
-    i INT;
-BEGIN
-    FOR i IN 1..10000 LOOP
-        INSERT INTO employees (
-            first_name, 
-            last_name, 
-            department_id, 
-            date_of_birth
-        )
-        VALUES (
-            'First' || i,                        -- Generate a first name
-            'Last' || i,                         -- Generate a last name
-            (i % 10) + 1,                        -- Cycle through 10 department IDs
-            DATE '1980-01-01' + (i % 365 * 365 / 30) -- Simulated birth dates
-        );
-    END LOOP;
-END $$;
+insert into employees (first_name, last_name, department_id, date_of_birth) 
+select 'First' || i, 'Last' || i, (i % 10) + 1, DATE '1980-01-01' + (i % 365 * 365 / 30) 
+from generate_series(1, 10001)i;
 
 SELECT relsizes_stats_schema.relsizes_collect_stats_once();
 

--- a/test/sql/gp_relsizes_stats.sql
+++ b/test/sql/gp_relsizes_stats.sql
@@ -1,1 +1,50 @@
 CREATE EXTENSION gp_relsizes_stats;
+
+DROP TABLE IF EXISTS employees;
+CREATE TABLE employees (
+    employee_id SERIAL PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    department_id INT,
+    date_of_birth DATE
+);
+
+INSERT INTO employees (first_name, last_name, department_id, date_of_birth) VALUES
+('John', 'Doe', 1, '1988-06-15'),
+('Jane', 'Smith', 2, '1990-07-20'),
+('Emily', 'Jones', 1, '1985-08-30');
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
+
+-- Fill table with a lot of different rows
+DO $$
+DECLARE
+    i INT;
+BEGIN
+    FOR i IN 1..10000 LOOP
+        INSERT INTO employees (
+            first_name, 
+            last_name, 
+            department_id, 
+            date_of_birth
+        )
+        VALUES (
+            'First' || i,                        -- Generate a first name
+            'Last' || i,                         -- Generate a last name
+            (i % 10) + 1,                        -- Cycle through 10 department IDs
+            DATE '1980-01-01' + (i % 365 * 365 / 30) -- Simulated birth dates
+        );
+    END LOOP;
+END $$;
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+
+-- Check that collected stats are correct
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+
+-- Validate that after rerun stats collection size of table has not change
+SELECT size FROM relsizes_stats_schema.table_sizes_history WHERE relname = 'employees';


### PR DESCRIPTION
Added a new SQL function relsizes_stats_schema.relsizes_collect_stats_once(), which utilizes the underlying C-function relsizes_collect_stats_once().

This function performs a single iteration of the relsizes_collect_stats() process, which is typically initiated by the main background worker.

Additionally, implemented functionality to enable or disable the main background worker responsible for statistics collection, allowing users to manually initiate statistics collection if desired and don't use background worker for that.

Add regression test for extension functionality.

Also, that PR resolve issue #13.
