### PR TITLE
Fix the calculation of a schema size when partitioned tables present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULE_big      = gp_relsizes_stats
 OBJS            = ./src/gp_relsizes_stats.o
 EXTENSION       = gp_relsizes_stats
-EXTVERSION      = 1.1
+EXTVERSION      = 1.2
 DATA            = $(wildcard sql/*--*.sql)
 REGRESS         = gp_relsizes_stats
 REGRESS_OPTS    = --inputdir=test/

--- a/gp_relsizes_stats.control
+++ b/gp_relsizes_stats.control
@@ -1,5 +1,5 @@
 # gp_relsizes_stats extension
 comment = 'gp_relsizes_stats - an extension to track table on-disc sizes in greenplum'
-default_version = '1.1'
+default_version = '1.2'
 module_pathname = '$libdir/gp_relsizes_stats'
 trusted = true

--- a/sql/gp_relsizes_stats--1.1--1.2.sql
+++ b/sql/gp_relsizes_stats--1.1--1.2.sql
@@ -1,0 +1,56 @@
+/* gp_relsizes_stats--1.1--1.2.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION gp_relsizes_stats" to load this file. \quit
+
+CREATE OR REPLACE VIEW relsizes_stats_schema.table_files AS
+    WITH part_oids AS (
+        SELECT n.nspname, c1.relname, c1.oid, true own_oid
+        FROM pg_class c1
+        JOIN pg_namespace n ON c1.relnamespace = n.oid
+        WHERE c1.reltablespace != (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_global')
+        UNION ALL
+        SELECT n.nspname, c1.relname, c2.oid, false own_oid
+        FROM pg_class c1
+        JOIN pg_namespace n ON c1.relnamespace = n.oid
+        JOIN pg_partition pp ON c1.oid = pp.parrelid
+        JOIN pg_partition_rule pr ON pp.oid = pr.paroid
+        JOIN pg_class c2 ON pr.parchildrelid = c2.oid
+        WHERE c1.reltablespace != (SELECT oid FROM pg_tablespace WHERE spcname = 'pg_global')
+    ),
+    table_oids AS (
+        SELECT po.nspname, po.relname, po.oid, po.own_oid, 'main' AS kind
+            FROM part_oids po
+        UNION ALL
+        SELECT po.nspname, po.relname, t.reltoastrelid, po.own_oid, 'toast' AS kind
+            FROM part_oids po
+            JOIN pg_class t ON po.oid = t.oid
+            WHERE t.reltoastrelid > 0
+        UNION ALL
+        SELECT po.nspname, po.relname, ti.indexrelid, po.own_oid, 'toast_idx' AS kind
+            FROM part_oids po
+            JOIN pg_class t ON po.oid = t.oid
+            JOIN pg_index ti ON t.reltoastrelid = ti.indrelid
+            WHERE t.reltoastrelid > 0
+        UNION ALL
+        SELECT po.nspname, po.relname, ao.segrelid, po.own_oid, 'ao' AS kind
+            FROM part_oids po
+            JOIN pg_appendonly ao ON po.oid = ao.relid
+        UNION ALL
+        SELECT po.nspname, po.relname, ao.visimaprelid, po.own_oid, 'ao_vm' AS kind
+            FROM part_oids po
+            JOIN pg_appendonly ao ON po.oid = ao.relid
+        UNION ALL
+        SELECT po.nspname, po.relname, ao.visimapidxid, po.own_oid, 'ao_vm_idx' AS kind
+            FROM part_oids po
+            JOIN pg_appendonly ao ON po.oid = ao.relid
+    )
+    SELECT table_oids.nspname, table_oids.relname, m.segment, m.relfilenode, fs.filepath, kind, size, mtime, table_oids.own_oid own_file
+    FROM table_oids
+    JOIN relsizes_stats_schema.segment_file_map m ON table_oids.oid = m.reloid
+    JOIN relsizes_stats_schema.segment_file_sizes fs ON m.segment = fs.segment AND m.relfilenode = fs.relfilenode;
+
+CREATE OR REPLACE VIEW relsizes_stats_schema.namespace_sizes AS
+    SELECT nspname, sum(size) AS size FROM relsizes_stats_schema.table_files
+    WHERE own_file
+    GROUP BY nspname;

--- a/test/expected/gp_relsizes_stats.out
+++ b/test/expected/gp_relsizes_stats.out
@@ -73,3 +73,115 @@ SELECT (EXTRACT(EPOCH FROM LOCALTIMESTAMP(0)) - :t1) < 5;
 
 -- Cleanup
 DROP TABLE t;
+--
+-- Check that schema size is calculated correctly when the schema
+-- contains partitioned tables and ordinary ones.
+-- start_ignore
+DROP SCHEMA IF EXISTS test CASCADE;
+NOTICE:  schema "test" does not exist, skipping
+-- end_ignore
+CREATE SCHEMA test;
+CREATE TABLE test.t1 (i INT, j INT)
+DISTRIBUTED BY (i)
+PARTITION BY RANGE (i)
+  SUBPARTITION BY RANGE (j)
+  SUBPARTITION TEMPLATE (SUBPARTITION sp START (0) END (2) EVERY(1))
+(PARTITION p START (0) END (3) EVERY(1));
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_1" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_1_2_prt_sp_1" for table "t1_1_prt_p_1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_1_2_prt_sp_2" for table "t1_1_prt_p_1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_2" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_2_2_prt_sp_1" for table "t1_1_prt_p_2"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_2_2_prt_sp_2" for table "t1_1_prt_p_2"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_3" for table "t1"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_3_2_prt_sp_1" for table "t1_1_prt_p_3"
+NOTICE:  CREATE TABLE will create partition "t1_1_prt_p_3_2_prt_sp_2" for table "t1_1_prt_p_3"
+INSERT INTO test.t1 (i, j)
+SELECT a % 3, a % 2 FROM generate_series(0, 2 * 3 - 1) a;
+CREATE TABLE test.t2 AS SELECT 1 i DISTRIBUTED BY(i);
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+SELECT size = 32768 * 2 * 3 /* t1 */ + 32768 /* t2 */
+  FROM relsizes_stats_schema.namespace_sizes
+ WHERE nspname = 'test';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT relname, segment, own_file, size
+  FROM relsizes_stats_schema.table_files
+ WHERE nspname = 'test'
+ORDER BY relname, segment, own_file;
+         relname         | segment | own_file | size  
+-------------------------+---------+----------+-------
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        | 32768
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        |     0
+ t1                      |       0 | f        | 32768
+ t1                      |       0 | f        |     0
+ t1                      |       0 | t        |     0
+ t1                      |       1 | f        |     0
+ t1                      |       1 | f        |     0
+ t1                      |       1 | f        |     0
+ t1                      |       1 | f        | 32768
+ t1                      |       1 | f        |     0
+ t1                      |       1 | f        | 32768
+ t1                      |       1 | f        | 32768
+ t1                      |       1 | f        | 32768
+ t1                      |       1 | f        |     0
+ t1                      |       1 | t        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | f        |     0
+ t1                      |       2 | t        |     0
+ t1_1_prt_p_1            |       0 | t        |     0
+ t1_1_prt_p_1            |       1 | t        |     0
+ t1_1_prt_p_1            |       2 | t        |     0
+ t1_1_prt_p_1_2_prt_sp_1 |       0 | t        |     0
+ t1_1_prt_p_1_2_prt_sp_1 |       1 | t        | 32768
+ t1_1_prt_p_1_2_prt_sp_1 |       2 | t        |     0
+ t1_1_prt_p_1_2_prt_sp_2 |       0 | t        |     0
+ t1_1_prt_p_1_2_prt_sp_2 |       1 | t        | 32768
+ t1_1_prt_p_1_2_prt_sp_2 |       2 | t        |     0
+ t1_1_prt_p_2            |       0 | t        |     0
+ t1_1_prt_p_2            |       1 | t        |     0
+ t1_1_prt_p_2            |       2 | t        |     0
+ t1_1_prt_p_2_2_prt_sp_1 |       0 | t        |     0
+ t1_1_prt_p_2_2_prt_sp_1 |       1 | t        | 32768
+ t1_1_prt_p_2_2_prt_sp_1 |       2 | t        |     0
+ t1_1_prt_p_2_2_prt_sp_2 |       0 | t        |     0
+ t1_1_prt_p_2_2_prt_sp_2 |       1 | t        | 32768
+ t1_1_prt_p_2_2_prt_sp_2 |       2 | t        |     0
+ t1_1_prt_p_3            |       0 | t        |     0
+ t1_1_prt_p_3            |       1 | t        |     0
+ t1_1_prt_p_3            |       2 | t        |     0
+ t1_1_prt_p_3_2_prt_sp_1 |       0 | t        | 32768
+ t1_1_prt_p_3_2_prt_sp_1 |       1 | t        |     0
+ t1_1_prt_p_3_2_prt_sp_1 |       2 | t        |     0
+ t1_1_prt_p_3_2_prt_sp_2 |       0 | t        | 32768
+ t1_1_prt_p_3_2_prt_sp_2 |       1 | t        |     0
+ t1_1_prt_p_3_2_prt_sp_2 |       2 | t        |     0
+ t2                      |       0 | t        |     0
+ t2                      |       1 | t        | 32768
+ t2                      |       2 | t        |     0
+(60 rows)
+
+DROP SCHEMA test CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table test.t1
+drop cascades to table test.t2


### PR DESCRIPTION
In the presence of partitioned tables, the size of their files was taken into
account twice when calculating the schema size.

Add the own_file column to table_files to distinguish its own table files from
files of its partitions. Use this new column to add the size of each file only
once when schema size is calculated.

In addition, replace UNION with UNION ALL to simplify the query plan, as
duplicate rows are not possible.