### PR TITLE
Disable Orca in workers

### DIFF
--- a/src/gp_relsizes_stats.c
+++ b/src/gp_relsizes_stats.c
@@ -351,6 +351,7 @@ void relsizes_database_stats_job(Datum args) {
     char *error = NULL;
     DbWorkerArg wa = { .d = args };
 
+    optimizer = false;
     pqsignal(SIGTERM, worker_sigterm);
     BackgroundWorkerUnblockSignals();
 
@@ -818,6 +819,7 @@ static void relsizes_collect_stats_once_internal(bool from_worker) {
  *       framework and runs in the "postgres" database context.
  */
 void relsizes_collect_stats(Datum main_arg) {
+    optimizer = false;
     pqsignal(SIGTERM, worker_sigterm);
     BackgroundWorkerUnblockSignals();
     BackgroundWorkerInitializeConnection("postgres", NULL);


### PR DESCRIPTION
Workers run queries which Orca cannot build plan for or which Orca cannot build
a better plan for. So use Postgres planner, because it is faster and there will
be no log records about "Feature not supported".