### PR TITLE
Non-super users can use the extension right after they create it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 MODULE_big      = gp_relsizes_stats
 OBJS            = ./src/gp_relsizes_stats.o
 EXTENSION       = gp_relsizes_stats
-EXTVERSION      = 1.2
+EXTVERSION      = 1.3
 DATA            = $(wildcard sql/*--*.sql)
-REGRESS         = gp_relsizes_stats
+REGRESS         = grants gp_relsizes_stats
 REGRESS_OPTS    = --inputdir=test/
 PGFILEDESC      = "gp_relsizes_stats - an extension to track table on-disc sizes in greenplum"
 PG_CXXFLAGS     += $(COMMON_CPP_FLAGS)

--- a/gp_relsizes_stats.control
+++ b/gp_relsizes_stats.control
@@ -1,5 +1,5 @@
 # gp_relsizes_stats extension
 comment = 'gp_relsizes_stats - an extension to track table on-disc sizes in greenplum'
-default_version = '1.2'
+default_version = '1.3'
 module_pathname = '$libdir/gp_relsizes_stats'
 trusted = true

--- a/sql/gp_relsizes_stats--1.2--1.3.sql
+++ b/sql/gp_relsizes_stats--1.2--1.3.sql
@@ -1,0 +1,9 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_relsizes_stats" to load this file. \quit
+
+DO $$
+BEGIN
+    EXECUTE 'GRANT USAGE ON SCHEMA relsizes_stats_schema TO "' || session_user || '" WITH GRANT OPTION';
+    EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA relsizes_stats_schema TO "' || session_user || '" WITH GRANT OPTION';
+END
+$$;

--- a/sql/gp_relsizes_stats--1.3.sql
+++ b/sql/gp_relsizes_stats--1.3.sql
@@ -1,5 +1,3 @@
-/* gp_relsizes_stats--1.2.sql */
-
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION gp_relsizes_stats" to load this file. \quit
 
@@ -88,3 +86,11 @@ CREATE FUNCTION relsizes_stats_schema.relsizes_collect_stats_once()
 RETURNS void
 AS 'MODULE_PATHNAME', 'relsizes_collect_stats_once'
 LANGUAGE C STRICT EXECUTE ON MASTER;
+
+
+DO $$
+BEGIN
+    EXECUTE 'GRANT USAGE ON SCHEMA relsizes_stats_schema TO "' || session_user || '" WITH GRANT OPTION';
+    EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA relsizes_stats_schema TO "' || session_user || '" WITH GRANT OPTION';
+END
+$$;

--- a/test/expected/grants.out
+++ b/test/expected/grants.out
@@ -1,0 +1,104 @@
+-- Check that user who has created gp_relsizes_stats have privileges to use all
+-- tables, views and functions from the extension.
+-- Check that this user can grant this privileges to others.
+SELECT '\! cp "' || setting || '/pg_hba.conf" "'  || setting || '/pg_hba.conf.backup"' as cp_backup
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+:cp_backup
+SELECT '\! echo "local all user1,user2 trust" >> ' || setting || '/pg_hba.conf' as add_users
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+:add_users
+CREATE ROLE user1 LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE user2 LOGIN RESOURCE QUEUE pg_default;
+CREATE DATABASE db1 OWNER user1;
+\set initial_user :USER
+\set initial_db :DBNAME
+\c db1 user1
+CREATE EXTENSION gp_relsizes_stats;
+-- Check that user who has created gp_relsizes_stats can use the extension
+SELECT FROM relsizes_stats_schema.segment_file_map LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.segment_file_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_sizes_history LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_files LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.namespace_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+SELECT FROM relsizes_stats_schema.get_stats_for_database(
+    (SELECT oid FROM pg_database WHERE datname = current_database()), true)
+LIMIT 0;
+--
+(0 rows)
+
+-- Check that user who has created gp_relsizes_stats can grant privileges to others
+GRANT USAGE ON SCHEMA relsizes_stats_schema TO user2;
+GRANT SELECT ON ALL TABLES IN SCHEMA relsizes_stats_schema TO user2;
+-- Check that user2 has got required privileges
+\c - user2
+SELECT FROM relsizes_stats_schema.segment_file_map LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.segment_file_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_sizes_history LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_files LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.table_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT FROM relsizes_stats_schema.namespace_sizes LIMIT 0;
+--
+(0 rows)
+
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+ relsizes_collect_stats_once 
+-----------------------------
+ 
+(1 row)
+
+SELECT FROM relsizes_stats_schema.get_stats_for_database(
+    (SELECT oid FROM pg_database WHERE datname = current_database()), true)
+LIMIT 0;
+--
+(0 rows)
+
+-- Cleanup
+\c :"initial_db" :"initial_user"
+DROP DATABASE db1;
+DROP ROLE user1, user2;
+SELECT '\! mv "' || setting || '/pg_hba.conf.backup" "' || setting || '/pg_hba.conf"' as cp_restore
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+:cp_restore

--- a/test/sql/grants.sql
+++ b/test/sql/grants.sql
@@ -1,0 +1,82 @@
+-- Check that user who has created gp_relsizes_stats have privileges to use all
+-- tables, views and functions from the extension.
+-- Check that this user can grant this privileges to others.
+
+-- start_ignore
+DROP DATABASE IF EXISTS db1;
+DROP ROLE IF EXISTS user1, user2;
+-- end_ignore
+
+SELECT '\! cp "' || setting || '/pg_hba.conf" "'  || setting || '/pg_hba.conf.backup"' as cp_backup
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+
+:cp_backup
+
+SELECT '\! echo "local all user1,user2 trust" >> ' || setting || '/pg_hba.conf' as add_users
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+
+:add_users
+
+-- start_ignore
+\! gpstop -u
+-- end_ignore
+
+CREATE ROLE user1 LOGIN RESOURCE QUEUE pg_default;
+CREATE ROLE user2 LOGIN RESOURCE QUEUE pg_default;
+CREATE DATABASE db1 OWNER user1;
+
+\set initial_user :USER
+\set initial_db :DBNAME
+
+\c db1 user1
+
+CREATE EXTENSION gp_relsizes_stats;
+
+-- Check that user who has created gp_relsizes_stats can use the extension
+SELECT FROM relsizes_stats_schema.segment_file_map LIMIT 0;
+SELECT FROM relsizes_stats_schema.segment_file_sizes LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_sizes_history LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_files LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_sizes LIMIT 0;
+SELECT FROM relsizes_stats_schema.namespace_sizes LIMIT 0;
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+
+SELECT FROM relsizes_stats_schema.get_stats_for_database(
+    (SELECT oid FROM pg_database WHERE datname = current_database()), true)
+LIMIT 0;
+
+-- Check that user who has created gp_relsizes_stats can grant privileges to others
+GRANT USAGE ON SCHEMA relsizes_stats_schema TO user2;
+GRANT SELECT ON ALL TABLES IN SCHEMA relsizes_stats_schema TO user2;
+
+-- Check that user2 has got required privileges
+\c - user2
+SELECT FROM relsizes_stats_schema.segment_file_map LIMIT 0;
+SELECT FROM relsizes_stats_schema.segment_file_sizes LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_sizes_history LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_files LIMIT 0;
+SELECT FROM relsizes_stats_schema.table_sizes LIMIT 0;
+SELECT FROM relsizes_stats_schema.namespace_sizes LIMIT 0;
+SELECT relsizes_stats_schema.relsizes_collect_stats_once();
+
+SELECT FROM relsizes_stats_schema.get_stats_for_database(
+    (SELECT oid FROM pg_database WHERE datname = current_database()), true)
+LIMIT 0;
+
+-- Cleanup
+\c :"initial_db" :"initial_user"
+
+DROP DATABASE db1;
+DROP ROLE user1, user2;
+
+SELECT '\! mv "' || setting || '/pg_hba.conf.backup" "' || setting || '/pg_hba.conf"' as cp_restore
+FROM pg_settings
+WHERE name = 'data_directory' \gset
+
+:cp_restore
+
+-- start_ignore
+\! gpstop -u
+-- end_ignore


### PR DESCRIPTION
Add privileges for user who creates gp_relsizes_stats to use all tables, views
and functions from the extension. This user can grant this privileges to others.
It is not necessary to grant EXECUTE on the functions, because users can
execute them by default when they have the USAGE privilege on the schema.